### PR TITLE
Add minimal C string_view helper library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # prompt_engineering
-example prompts for common LLM's 
+example prompts for common LLM's
 
 eerste experiment : [link naar c_coding_style.md](c_coding_style.md)
+
+## string_view voorbeeld
+Minimalistische C string_view helper (geïnspireerd door Tsoding) vind je in `include/mt_string_view.h` en `src/mt_string_view.c`. Bouw de demo met:
+
+```
+cc -std=c11 -Wall -Wextra -pedantic -Iinclude examples/mt_sv_example.c src/mt_string_view.c -o /tmp/mt_sv_example
+```

--- a/examples/mt_sv_example.c
+++ b/examples/mt_sv_example.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include "mt_string_view.h"
+
+static void print_sv(const char *label, mt_sv_t sv) {
+    printf("%s: '%.*s' (len=%zu)\n", label, (int)sv.len, sv.data ? sv.data : "", sv.len);
+}
+
+int main(void) {
+    mt_sv_t line = mt_sv_from_cstr("  host=example.com;port=8000  ");
+    line = mt_sv_trim(line);
+    print_sv("trimmed", line);
+
+    mt_sv_t iter = line;
+    while (iter.len > 0) {
+        mt_result_sv_t kv = mt_sv_chop_by_delim(&iter, ';');
+        mt_sv_t field = kv.ok ? kv.u.value : iter;
+        if (!kv.ok) {
+            iter = mt_sv_from_parts(NULL, 0);
+        }
+
+        mt_result_sv_pair_t split = mt_sv_split_first(field, '=');
+        if (!split.ok) {
+            printf("skip malformed field (%s)\n", mt_err_str(split.u.err));
+            continue;
+        }
+
+        mt_sv_t key = mt_sv_trim(split.u.value.head);
+        mt_sv_t val = mt_sv_trim(split.u.value.tail);
+        print_sv("key", key);
+        print_sv("val", val);
+    }
+
+    return 0;
+}

--- a/include/mt_err.h
+++ b/include/mt_err.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <stdint.h>
+
+// Generic error codes. All codes are positive; 0 equals success.
+typedef enum {
+    MT_OK = 0,
+    MT_ERR_NULL = 1,
+    MT_ERR_OOM = 2,
+    MT_ERR_IO = 3,
+    MT_ERR_RANGE = 4,
+    MT_ERR_PARSE = 5,
+    MT_ERR_BUSY = 6,
+    MT_ERR_TIMEOUT = 7,
+    MT_ERR_NOTFOUND = 8,
+    MT_ERR_PERM = 9,
+
+    MT_ERR_CUSTOM = 1000,
+    MT_ERR_SV_CHOP = MT_ERR_CUSTOM,
+    MT_ERR_SV_EMPTY,
+} mt_err_t;
+
+static inline const char *mt_err_str(mt_err_t err) {
+    switch (err) {
+    case MT_OK: return "MT_OK";
+    case MT_ERR_NULL: return "MT_ERR_NULL";
+    case MT_ERR_OOM: return "MT_ERR_OOM";
+    case MT_ERR_IO: return "MT_ERR_IO";
+    case MT_ERR_RANGE: return "MT_ERR_RANGE";
+    case MT_ERR_PARSE: return "MT_ERR_PARSE";
+    case MT_ERR_BUSY: return "MT_ERR_BUSY";
+    case MT_ERR_TIMEOUT: return "MT_ERR_TIMEOUT";
+    case MT_ERR_NOTFOUND: return "MT_ERR_NOTFOUND";
+    case MT_ERR_PERM: return "MT_ERR_PERM";
+    case MT_ERR_SV_CHOP: return "MT_ERR_SV_CHOP";
+    case MT_ERR_SV_EMPTY: return "MT_ERR_SV_EMPTY";
+    default: return "MT_ERR_UNKNOWN";
+    }
+}

--- a/include/mt_result.h
+++ b/include/mt_result.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <stdbool.h>
+#include "mt_err.h"
+
+typedef struct {
+    bool ok;
+    union {
+        void    *value;
+        mt_err_t err;
+    } u;
+} mt_result_t;
+
+#define RESULT_OK(v)   ((mt_result_t){ .ok = true,  .u.value = (v) })
+#define RESULT_ERR(e)  ((mt_result_t){ .ok = false, .u.err   = (e) })
+#define MT_RETURN_OK(v) return RESULT_OK(v)
+#define MT_RETURN_ERR(e) return RESULT_ERR(e)
+

--- a/include/mt_string_view.h
+++ b/include/mt_string_view.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <stddef.h>
+#include <stdbool.h>
+#include "mt_err.h"
+#include "mt_result.h"
+
+typedef struct {
+    const char *data;
+    size_t      len;
+} mt_sv_t;
+
+typedef struct {
+    bool ok;
+    union {
+        mt_sv_t  value;
+        mt_err_t err;
+    } u;
+} mt_result_sv_t;
+
+typedef struct {
+    mt_sv_t head;
+    mt_sv_t tail;
+} mt_sv_pair_t;
+
+typedef struct {
+    bool ok;
+    union {
+        mt_sv_pair_t value;
+        mt_err_t     err;
+    } u;
+} mt_result_sv_pair_t;
+
+#define MT_OK_SV(v)      ((mt_result_sv_t){ .ok = true,  .u.value = (v) })
+#define MT_ERR_SV(e)     ((mt_result_sv_t){ .ok = false, .u.err   = (e) })
+#define MT_OK_SV_PAIR(v) ((mt_result_sv_pair_t){ .ok = true,  .u.value = (v) })
+#define MT_ERR_SV_PAIR(e)((mt_result_sv_pair_t){ .ok = false, .u.err   = (e) })
+#define MT_RETURN_OK_SV(v)      return MT_OK_SV(v)
+#define MT_RETURN_ERR_SV(e)     return MT_ERR_SV(e)
+#define MT_RETURN_OK_SV_PAIR(v) return MT_OK_SV_PAIR(v)
+#define MT_RETURN_ERR_SV_PAIR(e) return MT_ERR_SV_PAIR(e)
+
+mt_sv_t mt_sv_from_parts(const char *data, size_t len);
+mt_sv_t mt_sv_from_cstr(const char *cstr);
+mt_sv_t mt_sv_trim(mt_sv_t sv);
+bool    mt_sv_equals(mt_sv_t a, mt_sv_t b);
+bool    mt_sv_starts_with(mt_sv_t sv, mt_sv_t prefix);
+mt_result_sv_t mt_sv_chop_left(mt_sv_t *sv, size_t count);
+mt_result_sv_t mt_sv_chop_by_delim(mt_sv_t *sv, char delim);
+mt_result_sv_pair_t mt_sv_split_first(mt_sv_t sv, char delim);

--- a/src/mt_string_view.c
+++ b/src/mt_string_view.c
@@ -1,0 +1,103 @@
+#include "mt_string_view.h"
+#include <ctype.h>
+#include <string.h>
+
+mt_sv_t mt_sv_from_parts(const char *data, size_t len) {
+    mt_sv_t sv = {0};
+    sv.data = data;
+    sv.len = data ? len : 0;
+    return sv;
+}
+
+mt_sv_t mt_sv_from_cstr(const char *cstr) {
+    if (!cstr) {
+        mt_sv_t empty = {0};
+        return empty;
+    }
+    return mt_sv_from_parts(cstr, strlen(cstr));
+}
+
+mt_sv_t mt_sv_trim(mt_sv_t sv) {
+    while (sv.len > 0 && isspace((unsigned char)sv.data[0])) {
+        sv.data += 1;
+        sv.len  -= 1;
+    }
+    while (sv.len > 0 && isspace((unsigned char)sv.data[sv.len - 1])) {
+        sv.len -= 1;
+    }
+    return sv;
+}
+
+bool mt_sv_equals(mt_sv_t a, mt_sv_t b) {
+    if (a.len != b.len) {
+        return false;
+    }
+    if (a.len == 0) {
+        return true;
+    }
+    return memcmp(a.data, b.data, a.len) == 0;
+}
+
+bool mt_sv_starts_with(mt_sv_t sv, mt_sv_t prefix) {
+    if (sv.len < prefix.len) {
+        return false;
+    }
+    if (prefix.len == 0) {
+        return true;
+    }
+    return memcmp(sv.data, prefix.data, prefix.len) == 0;
+}
+
+mt_result_sv_t mt_sv_chop_left(mt_sv_t *sv, size_t count) {
+    if (!sv) {
+        MT_RETURN_ERR_SV(MT_ERR_NULL);
+    }
+    if (count == 0) {
+        MT_RETURN_ERR_SV(MT_ERR_SV_EMPTY);
+    }
+    if (count > sv->len) {
+        MT_RETURN_ERR_SV(MT_ERR_RANGE);
+    }
+
+    mt_sv_t left = mt_sv_from_parts(sv->data, count);
+    sv->data += count;
+    sv->len  -= count;
+    MT_RETURN_OK_SV(left);
+}
+
+mt_result_sv_t mt_sv_chop_by_delim(mt_sv_t *sv, char delim) {
+    if (!sv) {
+        MT_RETURN_ERR_SV(MT_ERR_NULL);
+    }
+    if (!sv->data || sv->len == 0) {
+        MT_RETURN_ERR_SV(MT_ERR_SV_EMPTY);
+    }
+
+    for (size_t i = 0; i < sv->len; ++i) {
+        if (sv->data[i] == delim) {
+            mt_sv_t left = mt_sv_from_parts(sv->data, i);
+            sv->data += i + 1;
+            sv->len  -= i + 1;
+            MT_RETURN_OK_SV(left);
+        }
+    }
+
+    MT_RETURN_ERR_SV(MT_ERR_NOTFOUND);
+}
+
+mt_result_sv_pair_t mt_sv_split_first(mt_sv_t sv, char delim) {
+    if (!sv.data && sv.len > 0) {
+        MT_RETURN_ERR_SV_PAIR(MT_ERR_NULL);
+    }
+    for (size_t i = 0; i < sv.len; ++i) {
+        if (sv.data[i] == delim) {
+            mt_sv_pair_t pair = {
+                .head = mt_sv_from_parts(sv.data, i),
+                .tail = mt_sv_from_parts(sv.data + i + 1, sv.len - i - 1),
+            };
+            MT_RETURN_OK_SV_PAIR(pair);
+        }
+    }
+
+    MT_RETURN_ERR_SV_PAIR(MT_ERR_NOTFOUND);
+}


### PR DESCRIPTION
## Summary
- add a lightweight string_view helper inspired by tsoding with result-based error handling
- include reusable error/result headers and an example parsing demo

## Testing
- cc -std=c11 -Wall -Wextra -pedantic -Iinclude examples/mt_sv_example.c src/mt_string_view.c -o /tmp/mt_sv_example


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939d37586a4832b93aa99a2d1cc1b3e)