### PR TITLE
Add minimal Opus + ALSA LAN voice chat demo with CMake and README docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.16)
+project(opus_lan_chat C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_compile_options(-Wall -Wextra -Wpedantic -Wconversion -Wshadow -Wstrict-prototypes)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(OPUS REQUIRED opus)
+pkg_check_modules(ALSA REQUIRED alsa)
+
+add_executable(opus_lan_chat
+    src/opus_lan_chat.c
+)
+
+target_include_directories(opus_lan_chat PRIVATE
+    ${OPUS_INCLUDE_DIRS}
+    ${ALSA_INCLUDE_DIRS}
+)
+
+target_link_directories(opus_lan_chat PRIVATE
+    ${OPUS_LIBRARY_DIRS}
+    ${ALSA_LIBRARY_DIRS}
+)
+
+target_link_libraries(opus_lan_chat PRIVATE
+    ${OPUS_LIBRARIES}
+    ${ALSA_LIBRARIES}
+)
+
+target_compile_options(opus_lan_chat PRIVATE
+    ${OPUS_CFLAGS_OTHER}
+    ${ALSA_CFLAGS_OTHER}
+)

--- a/README.md
+++ b/README.md
@@ -9,3 +9,30 @@ Minimalistische C string_view helper (geïnspireerd door Tsoding) vind je in `in
 ```
 cc -std=c11 -Wall -Wextra -pedantic -Iinclude examples/mt_sv_example.c src/mt_string_view.c -o /tmp/mt_sv_example
 ```
+
+## Minimal Opus LAN voice chat (C + CMake)
+Voor moderne Linux desktop is **PipeWire** het meest gangbaar. Deze demo gebruikt de stabiele **ALSA API** (`default` device), die op PipeWire-systemen meestal automatisch via `pipewire-alsa` routed.
+
+Build:
+
+```bash
+cmake -S . -B build
+cmake --build build -j
+```
+
+Run op receiver host:
+
+```bash
+./build/opus_lan_chat rx 0.0.0.0 5000
+```
+
+Run op sender host:
+
+```bash
+./build/opus_lan_chat tx 192.168.1.50 5000
+```
+
+Kenmerken:
+- Mono 16 kHz, 20 ms frames
+- Opus VOIP mode, DTX + in-band FEC aan
+- UDP voor low-latency LAN point-to-point

--- a/src/opus_lan_chat.c
+++ b/src/opus_lan_chat.c
@@ -1,0 +1,288 @@
+#include <arpa/inet.h>
+#include <assert.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <alsa/asoundlib.h>
+#include <opus/opus.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+enum {
+    audio_sample_rate = 16000,
+    audio_channels = 1,
+    audio_frame_ms = 20,
+    audio_frame_samples = (audio_sample_rate / 1000) * audio_frame_ms,
+    opus_max_packet = 400,
+    app_invalid_fd = -1,
+};
+
+typedef enum {
+    app_ok = 0,
+    app_err_args,
+    app_err_parse,
+    app_err_range,
+    app_err_socket,
+    app_err_bind,
+    app_err_connect,
+    app_err_audio,
+    app_err_opus,
+    app_err_io,
+} app_err_t;
+
+#define app_assert_ptr(p) assert((p) != NULL)
+#define app_guard_ptr(p, err) do { if ((p) == NULL) { return (err); } } while (0)
+#define app_guard_range(v, lo, hi, err) do { if ((v) < (lo) || (v) > (hi)) { return (err); } } while (0)
+
+typedef struct {
+    int sock_fd;
+    snd_pcm_t *pcm;
+    OpusEncoder *enc;
+    OpusDecoder *dec;
+} app_ctx_t;
+
+static void app_ctx_init(app_ctx_t *ctx) {
+    app_assert_ptr(ctx);
+    ctx->sock_fd = app_invalid_fd;
+    ctx->pcm = NULL;
+    ctx->enc = NULL;
+    ctx->dec = NULL;
+}
+
+static void app_ctx_cleanup(app_ctx_t *ctx) {
+    app_assert_ptr(ctx);
+    if (ctx->enc != NULL) {
+        opus_encoder_destroy(ctx->enc);
+        ctx->enc = NULL;
+    }
+    if (ctx->dec != NULL) {
+        opus_decoder_destroy(ctx->dec);
+        ctx->dec = NULL;
+    }
+    if (ctx->pcm != NULL) {
+        snd_pcm_close(ctx->pcm);
+        ctx->pcm = NULL;
+    }
+    if (ctx->sock_fd >= 0) {
+        close(ctx->sock_fd);
+        ctx->sock_fd = app_invalid_fd;
+    }
+}
+
+static app_err_t net_sock_open_udp(int *out_fd) {
+    app_assert_ptr(out_fd);
+    app_guard_ptr(out_fd, app_err_args);
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        return app_err_socket;
+    }
+    *out_fd = fd;
+    return app_ok;
+}
+
+static app_err_t net_sock_bind(int fd, const char *ip, uint16_t port) {
+    app_assert_ptr(ip);
+    app_guard_ptr(ip, app_err_args);
+    app_guard_range(port, 1, UINT16_MAX, app_err_range);
+    if (fd < 0) {
+        return app_err_socket;
+    }
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    if (inet_pton(AF_INET, ip, &addr.sin_addr) != 1) {
+        return app_err_parse;
+    }
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        return app_err_bind;
+    }
+    return app_ok;
+}
+
+static app_err_t net_sock_connect(int fd, const char *ip, uint16_t port) {
+    app_assert_ptr(ip);
+    app_guard_ptr(ip, app_err_args);
+    app_guard_range(port, 1, UINT16_MAX, app_err_range);
+    if (fd < 0) {
+        return app_err_socket;
+    }
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    if (inet_pton(AF_INET, ip, &addr.sin_addr) != 1) {
+        return app_err_parse;
+    }
+    if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        return app_err_connect;
+    }
+    return app_ok;
+}
+
+static app_err_t audio_pcm_open(snd_pcm_t **pcm, snd_pcm_stream_t stream) {
+    app_assert_ptr(pcm);
+    app_guard_ptr(pcm, app_err_args);
+
+    int rc = snd_pcm_open(pcm, "default", stream, 0);
+    if (rc < 0 || *pcm == NULL) {
+        return app_err_audio;
+    }
+
+    rc = snd_pcm_set_params(*pcm, SND_PCM_FORMAT_S16_LE, SND_PCM_ACCESS_RW_INTERLEAVED,
+                            audio_channels, audio_sample_rate, 1, 2 * 1000);
+    if (rc < 0) {
+        snd_pcm_close(*pcm);
+        *pcm = NULL;
+        return app_err_audio;
+    }
+
+    return app_ok;
+}
+
+static app_err_t opus_enc_open(OpusEncoder **enc) {
+    app_assert_ptr(enc);
+    app_guard_ptr(enc, app_err_args);
+    int rc = OPUS_OK;
+    *enc = opus_encoder_create(audio_sample_rate, audio_channels, OPUS_APPLICATION_VOIP, &rc);
+    if (rc != OPUS_OK || *enc == NULL) {
+        return app_err_opus;
+    }
+    if (opus_encoder_ctl(*enc, OPUS_SET_BITRATE(20000)) != OPUS_OK) { return app_err_opus; }
+    if (opus_encoder_ctl(*enc, OPUS_SET_INBAND_FEC(1)) != OPUS_OK) { return app_err_opus; }
+    if (opus_encoder_ctl(*enc, OPUS_SET_DTX(1)) != OPUS_OK) { return app_err_opus; }
+    return app_ok;
+}
+
+static app_err_t opus_dec_open(OpusDecoder **dec) {
+    app_assert_ptr(dec);
+    app_guard_ptr(dec, app_err_args);
+    int rc = OPUS_OK;
+    *dec = opus_decoder_create(audio_sample_rate, audio_channels, &rc);
+    if (rc != OPUS_OK || *dec == NULL) {
+        return app_err_opus;
+    }
+    return app_ok;
+}
+
+static app_err_t app_run_tx(const char *dst_ip, uint16_t dst_port) {
+    app_assert_ptr(dst_ip);
+    app_guard_ptr(dst_ip, app_err_args);
+    app_guard_range(dst_port, 1, UINT16_MAX, app_err_range);
+
+    app_ctx_t ctx;
+    app_ctx_init(&ctx);
+    int16_t pcm[audio_frame_samples];
+    uint8_t pkt[opus_max_packet];
+
+    app_err_t rc = net_sock_open_udp(&ctx.sock_fd);
+    if (rc != app_ok) { return rc; }
+    rc = net_sock_connect(ctx.sock_fd, dst_ip, dst_port);
+    if (rc != app_ok) { app_ctx_cleanup(&ctx); return rc; }
+    rc = audio_pcm_open(&ctx.pcm, SND_PCM_STREAM_CAPTURE);
+    if (rc != app_ok) { app_ctx_cleanup(&ctx); return rc; }
+    rc = opus_enc_open(&ctx.enc);
+    if (rc != app_ok) { app_ctx_cleanup(&ctx); return rc; }
+
+    for (;;) {
+        snd_pcm_sframes_t got = snd_pcm_readi(ctx.pcm, pcm, audio_frame_samples);
+        if (got == -EPIPE) { snd_pcm_prepare(ctx.pcm); continue; }
+        if (got < 0) { rc = app_err_io; break; }
+        if (got != audio_frame_samples) { continue; }
+
+        int n = opus_encode(ctx.enc, pcm, audio_frame_samples, pkt, (opus_int32)sizeof(pkt));
+        if (n <= 0 || n > (int)sizeof(pkt)) { rc = app_err_opus; break; }
+
+        ssize_t sent = send(ctx.sock_fd, pkt, (size_t)n, 0);
+        if (sent != n) { rc = app_err_io; break; }
+    }
+
+    app_ctx_cleanup(&ctx);
+    return rc;
+}
+
+static app_err_t app_run_rx(const char *bind_ip, uint16_t bind_port) {
+    app_assert_ptr(bind_ip);
+    app_guard_ptr(bind_ip, app_err_args);
+    app_guard_range(bind_port, 1, UINT16_MAX, app_err_range);
+
+    app_ctx_t ctx;
+    app_ctx_init(&ctx);
+    uint8_t pkt[opus_max_packet];
+    int16_t pcm[audio_frame_samples];
+
+    app_err_t rc = net_sock_open_udp(&ctx.sock_fd);
+    if (rc != app_ok) { return rc; }
+    rc = net_sock_bind(ctx.sock_fd, bind_ip, bind_port);
+    if (rc != app_ok) { app_ctx_cleanup(&ctx); return rc; }
+    rc = audio_pcm_open(&ctx.pcm, SND_PCM_STREAM_PLAYBACK);
+    if (rc != app_ok) { app_ctx_cleanup(&ctx); return rc; }
+    rc = opus_dec_open(&ctx.dec);
+    if (rc != app_ok) { app_ctx_cleanup(&ctx); return rc; }
+
+    for (;;) {
+        ssize_t got = recv(ctx.sock_fd, pkt, sizeof(pkt), 0);
+        if (got <= 0 || got > (ssize_t)sizeof(pkt)) { rc = app_err_io; break; }
+
+        int n = opus_decode(ctx.dec, pkt, (opus_int32)got, pcm, audio_frame_samples, 0);
+        if (n < 0 || n > audio_frame_samples) { continue; }
+
+        snd_pcm_sframes_t wr = snd_pcm_writei(ctx.pcm, pcm, (snd_pcm_uframes_t)n);
+        if (wr == -EPIPE) { snd_pcm_prepare(ctx.pcm); continue; }
+        if (wr < 0) { rc = app_err_io; break; }
+    }
+
+    app_ctx_cleanup(&ctx);
+    return rc;
+}
+
+static app_err_t app_parse_port(const char *text, uint16_t *out_port) {
+    app_assert_ptr(text);
+    app_assert_ptr(out_port);
+    app_guard_ptr(text, app_err_args);
+    app_guard_ptr(out_port, app_err_args);
+
+    errno = 0;
+    char *end = NULL;
+    unsigned long value = strtoul(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0') {
+        return app_err_parse;
+    }
+    if (value == 0 || value > UINT16_MAX) {
+        return app_err_range;
+    }
+    *out_port = (uint16_t)value;
+    return app_ok;
+}
+
+static void app_usage(const char *prog) {
+    app_assert_ptr(prog);
+    fprintf(stderr, "usage:\n");
+    fprintf(stderr, "  %s tx <dst_ip> <port>\n", prog);
+    fprintf(stderr, "  %s rx <bind_ip> <port>\n", prog);
+}
+
+int main(int argc, char **argv) {
+    if (argc != 4 || argv == NULL || argv[0] == NULL || argv[1] == NULL || argv[2] == NULL || argv[3] == NULL) {
+        app_usage((argv && argv[0]) ? argv[0] : "opus_lan_chat");
+        return app_err_args;
+    }
+
+    uint16_t port = 0;
+    app_err_t parse_rc = app_parse_port(argv[3], &port);
+    if (parse_rc != app_ok) {
+        app_usage(argv[0]);
+        return parse_rc;
+    }
+
+    if (strcmp(argv[1], "tx") == 0) { return app_run_tx(argv[2], port); }
+    if (strcmp(argv[1], "rx") == 0) { return app_run_rx(argv[2], port); }
+
+    app_usage(argv[0]);
+    return app_err_args;
+}


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained LAN voice chat demo that uses Opus for codec and ALSA for audio I/O to demonstrate low-latency point-to-point audio over UDP.
- Offer a simple CMake-based build and usage instructions so the demo can be built and run on typical Linux desktops (including PipeWire via `pipewire-alsa`).

### Description
- Add `src/opus_lan_chat.c`, a single-file C demo implementing `tx` (capture, Opus encode, UDP send) and `rx` (UDP receive, Opus decode, playback) modes using ALSA and libopus, with sane defaults (16 kHz mono, 20 ms frames, VOIP settings, DTX/FEC enabled).
- Add `CMakeLists.txt` that finds `opus` and `alsa` via `pkg-config`, sets compile flags, and builds the `opus_lan_chat` executable while wiring include/link directories and flags (`pkg_check_modules(OPUS REQUIRED opus)`, `pkg_check_modules(ALSA REQUIRED alsa)`).
- Update `README.md` with build instructions (`cmake -S . -B build` / `cmake --build build -j`) and example run commands for receiver and sender, plus feature notes.

### Testing
- No automated tests were included or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6991a20d8a98832b86eec9e963c6ba2c)